### PR TITLE
WIP - Add credits page to piisa.org

### DIFF
--- a/docs/credit.md
+++ b/docs/credit.md
@@ -1,0 +1,15 @@
+# Projects that use PIISA
+
+This page lists major projects that use PIISA. 
+
+## Open Assistant
+
+Insert description here.
+
+## BILD
+
+Insert description here.
+
+## BigCode 
+
+Insert description here.


### PR DESCRIPTION
## Description

This PR adds a credits page that lists projects that have used PIISA. Please note that even the name of the file is not set in stone for now. Feel free to contribute the naming and description of the list.

## Changes
- [ ] Docs: Add a credit page that lists projects that have used PIISA

